### PR TITLE
[9.1.1-ibm-0001-quarkus-full] DBACLD-141936: Removing warning about dev services

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,8 +3,12 @@ quarkus.http.cors=true
 quarkus.smallrye-openapi.path=/docs/openapi.json
 quarkus.swagger-ui.always-include=true
 
-quarkus.kogito.devservices.enabled=false
-quarkus.devservices.enabled=false
+# Set these to true if dev services are being used in this project.
+# By default, they are not, and there are no dependencies which use them.
+# Read more about Quarkus DevServices at https://quarkus.io/guides/dev-services
+
+#quarkus.kogito.devservices.enabled=false
+#quarkus.devservices.enabled=false
 
 kogito.service.url=http://localhost:${quarkus.http.port}
 kogito.jobs-service.url=http://localhost:${quarkus.http.port}


### PR DESCRIPTION
Commenting quarkus properties that don't need to be there.